### PR TITLE
Fixed SET default values

### DIFF
--- a/lib/native_enum/activerecord_enum_post42.rb
+++ b/lib/native_enum/activerecord_enum_post42.rb
@@ -63,6 +63,18 @@ module ActiveRecord
       end
       # deserialize used to be called type_cast_from_database before v5
       alias_method :type_cast_from_database, :deserialize
+
+      def cast(value)
+        if value&.is_a?(Array)
+          value.join ','
+        else
+          value
+        end
+      end
+
+      def type_cast_for_schema(value)
+        %Q["#{value.join(',')}"]
+      end
     end
   end
 end

--- a/lib/native_enum/activerecord_enum_pre42.rb
+++ b/lib/native_enum/activerecord_enum_pre42.rb
@@ -28,7 +28,7 @@ module ActiveRecord
 
       def extract_default_with_enum default
         if type == :set
-          default.split "," if default.present?
+          default
         else
           extract_default default
         end

--- a/spec/set_spec.rb
+++ b/spec/set_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe "SET datatype" do
     end
 
     it "dumps default option" do
-      expect(subject).to match %r{t\.set\s+"gadgets",.+(:default =>|default:) \["propeller", "gps"\]}
+      expect(subject).to match %r{t\.set\s+"gadgets",.+(:default =>|default:) "propeller,gps"}
     end
 
     it "dumps null option" do


### PR DESCRIPTION
Currently, the gem outputs `['option1', 'option2']` as the default value to the schema dump. This results in "Cannot quote array" when trying to load the table from the schema.

Instead, the default value should end up being `'option1,option2'` since MySQL will handle the set parsing itself.

I've updated the post42 handler to implement `type_cast_for_schema` to join the array. For the pre42 handler, I updated `extract_default_with_enum` to just the joined string.

I've also included the `cast` function to automatically convert array value to their `SET` string implementation.